### PR TITLE
feat: only apply calendar buffer conditionally

### DIFF
--- a/src/components/CalendarForm.tsx
+++ b/src/components/CalendarForm.tsx
@@ -105,7 +105,8 @@ class CalendarForm extends React.Component<Props, MyState> {
 
     const tasks = filteredDates.map(function (task) {
 
-      let deadline = new Date(startDate.getTime() + (task.days - pufferDays) * 86400000)
+      let subtractFromDeadline = task.days < 0 ? pufferDays : 0
+      let deadline = new Date(startDate.getTime() + (task.days - subtractFromDeadline) * 86400000)
       if (task.days === -1000) {
         deadline = new Date(startDate.valueOf())
         deadline.setMonth(0)


### PR DESCRIPTION
As already discussed with @tobijuon ;)

The buffer now ony gets applied for dates before the camp.
Otherwise you could get the funny result, that you have to return your
maps before the camp even started, when using a buffer of 7 days…