### PR TITLE
make calendar table scrollable on smaller screens

### DIFF
--- a/src/styles/calendar.less
+++ b/src/styles/calendar.less
@@ -36,7 +36,16 @@
         width: 30%;
       }
     }
+
+    @media (max-width: 659px) {
+      table {
+        width: 100vw;
+        display: block;
+        overflow: scroll;
+      }
+    }
   }
+  
   .calendar-ics {
     margin-bottom: 20px;
   }


### PR DESCRIPTION
I've noticed that the generated calendar isn't horizontally scrollable on smaller screen sizes. Here's a little fix for that. Feel free to improve it 🙂