### PR TITLE
added ability to set a prefix for calendar entry titles

### DIFF
--- a/src/components/CalendarForm.tsx
+++ b/src/components/CalendarForm.tsx
@@ -150,7 +150,7 @@ class CalendarForm extends React.Component<Props, MyState> {
                 </select>
               </li>
               <li>
-                <button type="submit"> {t('calendarPage.generate')}</button>
+                <button type="submit"> {t('calendarPage.ics.generate')}</button>
               </li>
             </ul>
           </form>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -21,9 +21,13 @@
         "al": "Abteilungsleitung",
         "c": "Coach"
       },
-      "generate": "Generieren",
-      "download": "Download als .ics",
-      "filename": "Daten.ics",
+      "ics": {
+        "generate": "Generieren",
+        "download": "Download als .ics",
+        "filename": "Daten.ics",
+        "prefixPlaceholder": "Prefix für Titel der Kalendereinträge",
+        "prefixPreview": "Vorschau: {{calendarTitlePrefix}}Lagerdaten an Coach"
+      },
       "table": {
         "what": "Was",
         "who": "Wer",

--- a/src/styles/calendar.less
+++ b/src/styles/calendar.less
@@ -1,5 +1,13 @@
 .calendar {
   overflow-x: scroll;
+
+  input, select {
+    border: 1px solid black;
+    height: 30px;
+    width: 200px;
+    margin: 0;
+  }
+
   .calendar-table {
 
     ul {
@@ -37,8 +45,17 @@
       }
     }
   }
+  
   .calendar-ics {
     margin-bottom: 20px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+
+    .calendar-title-prefix-hint {
+      font-weight: 200;
+      font-size: 12px;
+    }
   }
 
   .calendar-form-container {
@@ -64,13 +81,6 @@
         align-items: center;
         justify-content: space-between;
         margin-top: 8px;
-
-        input, select {
-          border: 1px solid black;
-          height: 30px;
-          width: 200px;
-          margin: 0;
-        }
 
         #puffer {
           width: 197px;


### PR DESCRIPTION
As a Coach I missed the functionality to add prefixes for the event titles in the downloaded ICS file. With a prefix I'm able to distinguish my events for example by group / level (Pfadistufe, Wolfstufe etc.). I intentionally didn't specify the separator as some might prefer colons over a dash for example.

It can certainly be improved as React isn't my goto JS-Framework. 🙂 Italian and French translations are also missing.