### PR TITLE
feat: rewrite search with FlexSearch and improved result highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.1",
         "exceljs": "^4.4.0",
+        "flexsearch": "^0.8.212",
         "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.0",
         "ics": "^3.8.1",
@@ -26,9 +27,11 @@
         "react-i18next": "^15.1.0",
         "react-markdown": "^10.0.0",
         "react-tooltip": "^5.28.0",
-        "remark-gfm": "^4.0.0"
+        "remark-gfm": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
+        "@types/hast": "^3.0.4",
         "@types/node": "^24.6.2",
         "@types/react": "^18.2.54",
         "@types/react-dom": "^18.2.18",
@@ -2345,6 +2348,34 @@
           "optional": true
         }
       }
+    },
+    "node_modules/flexsearch": {
+      "version": "0.8.212",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.8.212.tgz",
+      "integrity": "sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/ts-thomas"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/donate/?hosted_button_id=GEVR88FC9BWRW"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/flexsearch"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/user?u=96245532"
+        },
+        {
+          "type": "liberapay",
+          "url": "https://liberapay.com/ts-thomas"
+        }
+      ],
+      "license": "Apache-2.0"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.1",
     "exceljs": "^4.4.0",
+    "flexsearch": "^0.8.212",
     "i18next": "^25.0.0",
     "i18next-browser-languagedetector": "^8.0.0",
     "ics": "^3.8.1",
@@ -48,9 +49,11 @@
     "react-i18next": "^15.1.0",
     "react-markdown": "^10.0.0",
     "react-tooltip": "^5.28.0",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@types/hast": "^3.0.4",
     "@types/node": "^24.6.2",
     "@types/react": "^18.2.54",
     "@types/react-dom": "^18.2.18",

--- a/src/apis/query-client.ts
+++ b/src/apis/query-client.ts
@@ -1,5 +1,7 @@
 import { QueryClient, } from '@tanstack/react-query'
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Infinity } },
+});
 
 export { queryClient }

--- a/src/pages/search/components/HighlightedText.tsx
+++ b/src/pages/search/components/HighlightedText.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+import { escapeRegex, normalize } from './search-helper'
+
+type Props = {
+    text: string
+    terms: string[]
+}
+
+/**
+ * Renders a plain string with matched search terms wrapped in <mark>.
+ * Matches are found against the diacritic-stripped, lowercased form of the text,
+ * but the original text is sliced for display. Same Latin-only assumption as
+ * rehype-highlight.ts (NFD-stripping preserves code-point count for DE/FR/IT).
+ */
+function HighlightedText({ text, terms }: Props) {
+    if (!terms.length) {
+        return <>{text}</>
+    }
+
+    const pattern = new RegExp(terms.map(escapeRegex).join('|'), 'gi')
+    const normalized = normalize(text)
+    const nodes: ReactNode[] = []
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+    let key = 0
+
+    while ((match = pattern.exec(normalized)) !== null) {
+        if (match.index > lastIndex) {
+            nodes.push(text.slice(lastIndex, match.index))
+        }
+        nodes.push(
+            <mark key={key++}>
+                {text.slice(match.index, match.index + match[0].length)}
+            </mark>
+        )
+        lastIndex = match.index + match[0].length
+    }
+
+    if (nodes.length === 0) {
+        return <>{text}</>
+    }
+
+    if (lastIndex < text.length) {
+        nodes.push(text.slice(lastIndex))
+    }
+
+    return <>{nodes}</>
+}
+
+export default HighlightedText

--- a/src/pages/search/components/SearchForm.tsx
+++ b/src/pages/search/components/SearchForm.tsx
@@ -4,11 +4,13 @@ import Loading from '../../../components/loading/Loading';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { LinkComponent } from '../../../helper/MarkdownComponents';
+import { rehypeHighlight } from './rehype-highlight';
+import HighlightedText from './HighlightedText';
 import SearchInput from './SearchInput';
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { loadSections } from "../../../apis/hering-api";
 import { useQuery } from "@tanstack/react-query";
-import { type SearchResult, preprocessSections, searchChapters } from "./search-helper";
+import { buildSearchIndex, searchChapters, type SearchResult } from "./search-helper";
 
 function SearchForm() {
 
@@ -17,109 +19,115 @@ function SearchForm() {
     const navigate = useNavigate()
     const { keyword: searchKeywordFromUrl } = useSearch({ from: '/search' })
 
-    const isQueryLoaded = useRef<boolean>(false);
-    const [keyword, setKeyword] = useState<string>('')
+    const [keyword, setKeyword] = useState<string>(searchKeywordFromUrl ?? '')
     const [searchResults, setSearchResults] = useState<SearchResult[]>([])
-    const [isLoadingResults, setIsLoadingResults] = useState<boolean>(false)
+    const [isSearchPending, setIsSearchPending] = useState<boolean>(false)
 
     const timeoutId = useRef<number | undefined>();
-    const { data: preprocessedChapters = [], isSuccess: isSectionsLoaded } = useQuery({
+    const { data: searchIndex, isLoading: isIndexLoading, isSuccess: isSectionsLoaded } = useQuery({
         queryKey: ['sections', lang],
         queryFn: async () => await loadSections(lang),
-        select: preprocessSections
+        select: buildSearchIndex
     })
 
     const executeSearch = useCallback((currentKeyword: string) => {
-        setIsLoadingResults(true)
-
         if (timeoutId.current) {
             clearTimeout(timeoutId.current);
         }
 
-        timeoutId.current = setTimeout(() => {
-            if (!currentKeyword || currentKeyword.length < 3) {
-                setSearchResults([])
-                setIsLoadingResults(false)
-                return
-            }
+        if (!currentKeyword || currentKeyword.length < 3 || !searchIndex) {
+            setSearchResults([])
+            setIsSearchPending(false)
+            return
+        }
 
-            const searchResults = searchChapters(currentKeyword, preprocessedChapters)
-
-            setSearchResults(searchResults)
-            setIsLoadingResults(false)
-
+        setIsSearchPending(true)
+        timeoutId.current = window.setTimeout(() => {
+            setSearchResults(searchChapters(currentKeyword, searchIndex))
+            setIsSearchPending(false)
             timeoutId.current = undefined;
         }, 500)
-    }, [preprocessedChapters])
+    }, [searchIndex])
 
+    // Keep state in sync with the URL so browser back/forward restores the keyword.
     useEffect(() => {
-        if (!isQueryLoaded.current) {
-            if (searchKeywordFromUrl) {
-                setKeyword(searchKeywordFromUrl)
-            }
-            isQueryLoaded.current = true;
-        }
+        setKeyword(searchKeywordFromUrl ?? '')
     }, [searchKeywordFromUrl]);
 
+    // Re-run the search whenever the keyword or the loaded index changes.
     useEffect(() => {
-        if (keyword.length >= 3) {
-            executeSearch(keyword)
-        }
-    }, [executeSearch]);
+        executeSearch(keyword)
+    }, [executeSearch, keyword]);
 
-    const onChangeKeyword = (e: React.FormEvent<HTMLInputElement>): void => {
+    const onChangeKeyword = async (e: React.FormEvent<HTMLInputElement>): Promise<void> => {
         e.preventDefault();
         const keyword = e.currentTarget?.value ?? ''
 
         setKeyword(keyword)
-        navigate({
+        await navigate({
             to: '/search',
             search: keyword.length > 0
                 ? { keyword }
                 : {},
             replace: true,
         })
+    }
 
-        executeSearch(keyword)
+    async function handleSearchResultClick(result: SearchResult, event: React.MouseEvent<HTMLDivElement>): Promise<void> {
+        // Skip card navigation when the click originated on a link inside the rendered markdown,
+        // so the link's own navigation (e.g. opening an external URL in a new tab) is the only thing that happens.
+        if ((event.target as HTMLElement).closest('a')) {
+            return
+        }
+
+        await navigate({
+            to: '/$sectionId',
+            params: { sectionId: result.sectionId },
+            hash: result.chapterId,
+        })
     }
 
     const searchResultViews = () => {
-        if (!isLoadingResults) {
-            if (keyword.length >= 3) {
-                if (searchResults.length > 0) {
-                    return searchResults.map(result => {
-                        return <div key={result.chapterId} className='search-result' onClick={() => navigate({
-                            to: '/$sectionId',
-                            params: { sectionId: result.sectionId },
-                            hash: result.chapterId,
-                        })}>
-                            <div className={'result-title'}>{result.title}</div>
-                            {result.matchingContents.length > 0 ?
-                                <div className='content-match'>
-                                    {result.matchingContents.map((content, idx) => {
-                                        return <Markdown key={idx}
-                                                         remarkPlugins={[remarkGfm]}
-                                                         components={LinkComponent}>{content}</Markdown>
-                                    })}
-                                </div>
-                                : null
-                            }
-                        </div>
-                    })
-                }
+        if (isIndexLoading) {
+            return null
+        }
 
-                return <div>{t('searchPage.noResults')}</div>
+        if (keyword.length >= 3) {
+            if (searchResults.length === 0 && isSearchPending) {
+                return null
             }
 
-            return <div> {t('searchPage.noKeyword', { amountOfCharacters: 3 })}</div>
+            if (searchResults.length > 0) {
+                return searchResults.map(result => {
+                    return <div key={result.chapterId} className='search-result' onClick={e => handleSearchResultClick(result, e)}>
+                        <div className={'result-title'}>
+                            <HighlightedText text={result.title} terms={result.matchedTerms}/>
+                        </div>
+                        {result.matchingContents.length > 0 ?
+                            <div className='content-match'>
+                                {result.matchingContents.map((content, idx) => {
+                                    return <Markdown key={idx}
+                                                     remarkPlugins={[remarkGfm]}
+                                                     rehypePlugins={[rehypeHighlight(result.matchedTerms)]}
+                                                     components={LinkComponent}>{content}</Markdown>
+                                })}
+                            </div>
+                            : null
+                        }
+                    </div>
+                })
+            }
+
+            return <div>{t('searchPage.noResults')}</div>
         }
-        return null
+
+        return <div> {t('searchPage.noKeyword', { amountOfCharacters: 3 })}</div>
     }
 
     return <>
         <SearchInput keyword={keyword} onChange={onChangeKeyword} isDisabled={!isSectionsLoaded}/>
         <br/>
-        <Loading isLoading={isLoadingResults}></Loading>
+        <Loading isLoading={isIndexLoading || isSearchPending}></Loading>
         <div className='search-results'>
             {searchResultViews()}
         </div>

--- a/src/pages/search/components/SearchForm.tsx
+++ b/src/pages/search/components/SearchForm.tsx
@@ -6,42 +6,9 @@ import remarkGfm from 'remark-gfm';
 import { LinkComponent } from '../../../helper/MarkdownComponents';
 import SearchInput from './SearchInput';
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { SearchHelper } from "../../../helper/SearchHelper";
-import { type  HApiChapter, type HApiSection, loadSections } from "../../../apis/hering-api";
+import { loadSections } from "../../../apis/hering-api";
 import { useQuery } from "@tanstack/react-query";
-
-type SearchResult = {
-    chapterId: string
-    sectionId: string
-    title: string
-    matchingContents: string[]
-}
-
-interface ChapterWithSection {
-    sectionId: string;
-    chapter: HApiChapter;
-    sentences: string[];
-}
-
-const markdownLinkRegex = /!?\[(.*?)]\((.*?)\)/gmi
-const sentenceRegex = /[^.!?:;#\n]*[^.!?:;#\n\s][^.!?:;#\n]*[.!?]+/g
-
-const preprocessSections = (sections: HApiSection[]): ChapterWithSection[] => {
-    return sections.reduce(
-        (chapterInfo: ChapterWithSection[], section: HApiSection) => chapterInfo.concat(
-            section.chapters.map(chapter => {
-                const filteredContent = chapter.content.replace(markdownLinkRegex, '')
-                const sentences = filteredContent.match(sentenceRegex) || []
-                return {
-                    sectionId: section.documentId,
-                    chapter: chapter,
-                    sentences: sentences.map(s => s.trim())
-                }
-            })
-        ),
-        []
-    )
-}
+import { type SearchResult, preprocessSections, searchChapters } from "./search-helper";
 
 function SearchForm() {
 
@@ -76,16 +43,7 @@ function SearchForm() {
                 return
             }
 
-            const searchResults = preprocessedChapters
-                .filter(entry => SearchHelper.matches(currentKeyword, [entry.chapter.title, entry.chapter.content]))
-                .map(entry => {
-                    return {
-                        chapterId: entry.chapter.documentId,
-                        sectionId: entry.sectionId,
-                        title: entry.chapter.title,
-                        matchingContents: findMatchingContents(currentKeyword, entry.sentences),
-                    } as SearchResult
-                })
+            const searchResults = searchChapters(currentKeyword, preprocessedChapters)
 
             setSearchResults(searchResults)
             setIsLoadingResults(false)
@@ -108,11 +66,6 @@ function SearchForm() {
             executeSearch(keyword)
         }
     }, [executeSearch]);
-
-    const findMatchingContents = (keyword: string, sentences: string[]): string[] => {
-        const normalizedKeyword = keyword.toLowerCase()
-        return sentences.filter(sentence => sentence.toLowerCase().includes(normalizedKeyword))
-    }
 
     const onChangeKeyword = (e: React.FormEvent<HTMLInputElement>): void => {
         e.preventDefault();

--- a/src/pages/search/components/rehype-highlight.ts
+++ b/src/pages/search/components/rehype-highlight.ts
@@ -1,0 +1,69 @@
+import type { Element, Root, RootContent, Text } from 'hast'
+import { SKIP, visit } from 'unist-util-visit'
+import { escapeRegex, normalize } from './search-helper'
+
+/**
+ * Creates a rehype plugin that wraps matched search terms in <mark> elements.
+ * Operates on the hast (HTML AST) level, splitting text nodes so that matched
+ * portions are wrapped in <mark>. Only text nodes are touched, so the surrounding
+ * Markdown structure (links, headings, etc.) is preserved.
+ */
+export const rehypeHighlight = (terms: string[]) => {
+    return () => (tree: Root) => {
+        if (!terms.length) {
+            return
+        }
+
+        const searchPattern = new RegExp(terms.map(t => escapeRegex(t)).join('|'), 'gi')
+
+        visit(tree, 'text', (node: Text, index, parent) => {
+            if (parent === undefined || index === undefined || !('children' in parent)) {
+                return
+            }
+
+            // The regex runs against `normalize(node.value)` but slices the original
+            // `node.value` using the match offsets. This assumes `normalize` preserves
+            // code-point count — true for Latin text (DE/FR/IT), because NFD-stripping
+            // only removes combining marks. If the corpus ever includes scripts where
+            // case/normalization changes length (e.g. Turkish dotted-I, Greek sigma),
+            // we would need an offset map from normalized → original indices.
+            const normalizedValue = normalize(node.value)
+            const parts: RootContent[] = []
+            let lastIndex = 0
+            let match: RegExpExecArray | null
+
+            searchPattern.lastIndex = 0
+            while ((match = searchPattern.exec(normalizedValue)) !== null) {
+                if (match.index > lastIndex) {
+                    parts.push({ type: 'text', value: node.value.slice(lastIndex, match.index) })
+                }
+                const markNode: Element = {
+                    type: 'element',
+                    tagName: 'mark',
+                    properties: {},
+                    children: [{
+                        type: 'text',
+                        value: node.value.slice(match.index, match.index + match[0].length),
+                    }],
+                }
+                parts.push(markNode)
+                lastIndex = match.index + match[0].length
+            }
+
+            if (parts.length === 0) {
+                return
+            }
+
+            if (lastIndex < node.value.length) {
+                parts.push({ type: 'text', value: node.value.slice(lastIndex) })
+            }
+
+            parent.children.splice(index, 1, ...parts)
+
+            // Skip past the newly inserted nodes so the walker does not re-enter
+            // the <mark>'s text child (which equals the matched substring and
+            // would otherwise be re-wrapped).
+            return [SKIP, index + parts.length]
+        })
+    }
+}

--- a/src/pages/search/components/search-helper.ts
+++ b/src/pages/search/components/search-helper.ts
@@ -1,17 +1,12 @@
-import { type HApiChapter, type HApiSection } from "../../../apis/hering-api";
+import { Document } from 'flexsearch';
+import { type HApiSection } from "../../../apis/hering-api";
 
 export type SearchResult = {
     chapterId: string
     sectionId: string
     title: string
     matchingContents: string[]
-}
-
-export interface ChapterWithSection {
-    sectionId: string;
-    chapter: HApiChapter;
-    paragraphs: Paragraph[];
-    normalizedTitle: string;
+    matchedTerms: string[]
 }
 
 interface Paragraph {
@@ -19,14 +14,25 @@ interface Paragraph {
     plainText: string;
 }
 
-const markdownLinkRegex = /!?\[(.*?)]\((.*?)\)/gmi
+interface IndexedChapter {
+    id: string;
+    sectionId: string;
+    title: string;
+    paragraphs: Paragraph[];
+}
+
+type ChapterDocument = {
+    id: string;
+    title: string;
+    content: string;
+}
 
 /**
  * Normalizes a string for diacritic-insensitive and case-insensitive comparison.
  * Uses Unicode NFD decomposition to separate base characters from combining accents,
  * then strips the accents. This ensures e.g. "équipe" matches a search for "equipe".
  */
-const normalize = (value: string): string => {
+export const normalize = (value: string): string => {
     return value
         .toLowerCase()
         .normalize('NFD')
@@ -34,11 +40,21 @@ const normalize = (value: string): string => {
 }
 
 /**
+ * Escapes regex metacharacters in a string so it can be interpolated into a
+ * RegExp and matched literally. Without this, characters like ".", "(", or "*"
+ * would be interpreted by the engine — a query of "..." would match any three
+ * characters, and an unbalanced "(" would throw SyntaxError.
+ */
+export const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
  * Splits Markdown content into paragraphs (by double newlines) and produces both the
  * original text (with Markdown links intact for rendering) and a plain-text version
  * (links replaced by their display text, normalized) for search matching.
  */
 const extractParagraphs = (content: string): Paragraph[] => {
+    const markdownLinkRegex = /!?\[(.*?)]\((.*?)\)/gmi
+
     return content
         .split(/\n\n+/)
         .map(p => p.trim())
@@ -49,53 +65,90 @@ const extractParagraphs = (content: string): Paragraph[] => {
         }))
 }
 
-/**
- * Flattens sections into a list of chapters enriched with pre-extracted paragraphs
- * and normalized titles. Intended to be executed sparingly as pre-processing the paragraphs
- * can be expensive.
- */
-export const preprocessSections = (sections: HApiSection[]): ChapterWithSection[] => {
-    return sections.reduce(
-        (chapterInfo: ChapterWithSection[], section: HApiSection) => chapterInfo.concat(
-            section.chapters.map(chapter => ({
-                sectionId: section.documentId,
-                chapter: chapter,
-                paragraphs: extractParagraphs(chapter.content),
-                normalizedTitle: normalize(chapter.title),
-            }))
-        ),
-        []
-    )
+export interface SearchIndex {
+    flexSearch: Document<ChapterDocument>;
+    chapters: Map<string, IndexedChapter>;
 }
 
 /**
- * Searches preprocessed chapters for a keyword string. The keyword is split into
- * space-separated terms; a chapter matches if any term appears in its title or in
- * any of its paragraphs. Matching paragraphs are returned with their original
- * Markdown content preserved so they can be rendered with links intact.
+ * Builds a FlexSearch Document index from sections. Flattens all chapters into
+ * searchable documents with title and content fields. Uses the "full" tokenizer,
+ * which indexes every substring of every token so that queries can match
+ * mid-word. This is necessary for German compound words where users search for
+ * e.g. "dossier" and expect to hit "Lagerdossier". The "Normalize" encoder
+ * handles diacritic-insensitive search across DE/FR/IT content.
  */
-export const searchChapters = (keyword: string, chapters: ChapterWithSection[]): SearchResult[] => {
-    const normalizedTerms = keyword
-        .split(' ')
-        .filter(t => t.length > 0)
-        .map(t => normalize(t))
+export const buildSearchIndex = (sections: HApiSection[]): SearchIndex => {
+    const chapters = new Map<string, IndexedChapter>()
 
-    const results: SearchResult[] = []
-    for (const entry of chapters) {
-        const matchingParagraphs = entry.paragraphs.filter(p =>
-            normalizedTerms.some(term => p.plainText.includes(term))
-        )
-        const titleMatches = normalizedTerms.some(term => entry.normalizedTitle.includes(term))
+    const flexSearch = new Document<ChapterDocument>({
+        tokenize: "full",
+        encoder: "Normalize",
+        document: {
+            id: "id",
+            index: ["title", "content"],
+        },
+    })
 
-        if (matchingParagraphs.length > 0 || titleMatches) {
-            results.push({
-                chapterId: entry.chapter.documentId,
-                sectionId: entry.sectionId,
-                title: entry.chapter.title,
-                matchingContents: matchingParagraphs.map(p => p.original),
+    for (const section of sections) {
+        for (const chapter of section.chapters) {
+            const paragraphs = extractParagraphs(chapter.content)
+            chapters.set(chapter.documentId, {
+                id: chapter.documentId,
+                sectionId: section.documentId,
+                title: chapter.title,
+                paragraphs,
+            })
+
+            flexSearch.add({
+                id: chapter.documentId,
+                title: chapter.title,
+                content: paragraphs.map(p => p.plainText).join(' '),
             })
         }
     }
 
-    return results
+    return { flexSearch, chapters }
+}
+
+/**
+ * Searches the FlexSearch index for a keyword string. Results are deduplicated
+ * across fields (title and content). For each matching chapter, paragraphs
+ * containing any of the search terms are returned with their original Markdown
+ * content preserved for rendering.
+ */
+export const searchChapters = (keyword: string, index: SearchIndex): SearchResult[] => {
+    const hits = index.flexSearch.search(keyword, { merge: true, suggest: true })
+
+    const normalizedTerms = keyword
+        .split(/\s+/)
+        .filter(t => t.length > 0)
+        .map(t => normalize(t))
+
+    return hits.flatMap(hit => {
+        const chapter = index.chapters.get(hit.id as string)
+        if (!chapter) {
+            return []
+        }
+
+        const matchingParagraphs = chapter.paragraphs.filter(p =>
+            normalizedTerms.some(term => p.plainText.includes(term))
+        )
+
+        // Title-only hits have no matching paragraphs — fall back to the first
+        // paragraph so the result card shows an excerpt instead of a bare title.
+        const matchingContents = matchingParagraphs.length > 0
+            ? matchingParagraphs.map(p => p.original)
+            : chapter.paragraphs.length > 0
+                ? [chapter.paragraphs[0].original]
+                : []
+
+        return [{
+            chapterId: chapter.id,
+            sectionId: chapter.sectionId,
+            title: chapter.title,
+            matchingContents,
+            matchedTerms: normalizedTerms,
+        }]
+    })
 }

--- a/src/pages/search/components/search-helper.ts
+++ b/src/pages/search/components/search-helper.ts
@@ -1,0 +1,101 @@
+import { type HApiChapter, type HApiSection } from "../../../apis/hering-api";
+
+export type SearchResult = {
+    chapterId: string
+    sectionId: string
+    title: string
+    matchingContents: string[]
+}
+
+export interface ChapterWithSection {
+    sectionId: string;
+    chapter: HApiChapter;
+    paragraphs: Paragraph[];
+    normalizedTitle: string;
+}
+
+interface Paragraph {
+    original: string;
+    plainText: string;
+}
+
+const markdownLinkRegex = /!?\[(.*?)]\((.*?)\)/gmi
+
+/**
+ * Normalizes a string for diacritic-insensitive and case-insensitive comparison.
+ * Uses Unicode NFD decomposition to separate base characters from combining accents,
+ * then strips the accents. This ensures e.g. "équipe" matches a search for "equipe".
+ */
+const normalize = (value: string): string => {
+    return value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+}
+
+/**
+ * Splits Markdown content into paragraphs (by double newlines) and produces both the
+ * original text (with Markdown links intact for rendering) and a plain-text version
+ * (links replaced by their display text, normalized) for search matching.
+ */
+const extractParagraphs = (content: string): Paragraph[] => {
+    return content
+        .split(/\n\n+/)
+        .map(p => p.trim())
+        .filter(p => p.length > 0)
+        .map(p => ({
+            original: p,
+            plainText: normalize(p.replace(markdownLinkRegex, '$1')),
+        }))
+}
+
+/**
+ * Flattens sections into a list of chapters enriched with pre-extracted paragraphs
+ * and normalized titles. Intended to be executed sparingly as pre-processing the paragraphs
+ * can be expensive.
+ */
+export const preprocessSections = (sections: HApiSection[]): ChapterWithSection[] => {
+    return sections.reduce(
+        (chapterInfo: ChapterWithSection[], section: HApiSection) => chapterInfo.concat(
+            section.chapters.map(chapter => ({
+                sectionId: section.documentId,
+                chapter: chapter,
+                paragraphs: extractParagraphs(chapter.content),
+                normalizedTitle: normalize(chapter.title),
+            }))
+        ),
+        []
+    )
+}
+
+/**
+ * Searches preprocessed chapters for a keyword string. The keyword is split into
+ * space-separated terms; a chapter matches if any term appears in its title or in
+ * any of its paragraphs. Matching paragraphs are returned with their original
+ * Markdown content preserved so they can be rendered with links intact.
+ */
+export const searchChapters = (keyword: string, chapters: ChapterWithSection[]): SearchResult[] => {
+    const normalizedTerms = keyword
+        .split(' ')
+        .filter(t => t.length > 0)
+        .map(t => normalize(t))
+
+    const results: SearchResult[] = []
+    for (const entry of chapters) {
+        const matchingParagraphs = entry.paragraphs.filter(p =>
+            normalizedTerms.some(term => p.plainText.includes(term))
+        )
+        const titleMatches = normalizedTerms.some(term => entry.normalizedTitle.includes(term))
+
+        if (matchingParagraphs.length > 0 || titleMatches) {
+            results.push({
+                chapterId: entry.chapter.documentId,
+                sectionId: entry.sectionId,
+                title: entry.chapter.title,
+                matchingContents: matchingParagraphs.map(p => p.original),
+            })
+        }
+    }
+
+    return results
+}

--- a/src/pages/search/search.less
+++ b/src/pages/search/search.less
@@ -4,6 +4,12 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+
+  mark {
+    background-color: #fff3a3;
+    color: inherit;
+    border-radius: 2px;
+  }
 }
 
 .search-result {
@@ -42,7 +48,9 @@
   }
 
   .result-title {
-    color: @color-primary-light;
+    color: #222;
+    font-size: 18px;
+    font-weight: 600;
   }
 
   .content-match {


### PR DESCRIPTION
- Replaces the custom substring-matching search with https://github.com/nextapps-de/flexsearch for better full-text search accuracy across DE/FR/IT content
- Extracts search logic into search-helper.ts (buildSearchIndex, searchChapters) and a custom rehype-highlight.ts rehype plugin for term highlighting in rendered Markdown
- Adds HighlightedText component to highlight matched terms in plain-text titles (diacritic-aware, NFD-normalized for consistent DE/FR/IT matching)
- Fixes search to preserve Markdown markup in results instead of stripping it before display
- Session-caches loaded section data indefinitely (no refetch within a session) via query-client.ts  